### PR TITLE
Fix/key collisions

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+x.x.x (YYYY-MM-DD)
+------------------
+
+* Added cache key collision checking
+
+
 0.1.1 (2017-09-01)
 ------------------
 

--- a/tests/test_class.py
+++ b/tests/test_class.py
@@ -46,10 +46,12 @@ def test_cached(cache_obj):
         cache_obj.test1(8, 0)
 
     assert len(c) == 1
+    assert cache_obj.test1(8, 0) == 1
 
     for _ in range(10):
         cache_obj.test2()
 
+    assert cache_obj.test2() == 1
     assert len(c) == 2
 
     c.clear()
@@ -68,7 +70,7 @@ def test_keyed_cached(cache_obj):
     assert len(c) == 1
 
     key = list(c.keys())[0]
-    assert key.endswith('asdf')
+    assert key == 'asdf'
 
     c.clear()
     assert len(c) == 0
@@ -116,7 +118,7 @@ def test_counters(cache_obj):
         cache_obj.test3(8, 2)
 
     assert len(c.counters) == 1
-    assert c.counters['myapp|test3|asdf'] == 9
+    assert c.counters['asdf'] == 9
 
     print(c.dump())
     c.counters.clear()

--- a/tests/test_collide.py
+++ b/tests/test_collide.py
@@ -1,0 +1,54 @@
+from __future__ import print_function
+import pytest
+from yamicache.yamicache import Cache
+
+c = Cache(prefix='myapp', hashing=False, debug=False)
+
+class App1(object):
+    @c.cached()
+    def test1(self, argument, power):
+        '''running test1'''
+        return argument ** power
+
+    @c.cached(key='test')
+    def test2(self):
+        return 0
+
+
+class App2(object):
+    @c.cached()
+    def test1(self, argument, power):
+        '''running test1'''
+        return argument ** power
+
+
+def test_avoide_collision():
+    '''Make sure cache keys don't collide'''
+    a1 = App1()
+    a2 = App2()
+
+    assert len(c) == 0
+
+    a1.test1(1, 2)
+    assert len(c) == 1
+
+    a2.test1(1, 2)
+    assert len(c) == 2
+    print(c.dump())
+
+
+def test_raises():
+    '''Ensure same key raises ValueError'''
+
+    with pytest.raises(ValueError):
+        @c.cached(key='test')
+        def test2(self):
+            return 0
+
+
+def main():
+    test_raises()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,47 @@
+from __future__ import print_function
+from yamicache.yamicache import Cache, INIT_CACHE_VALUE
+
+c = Cache(hashing=False)
+
+
+class MyApp(object):
+    @c.cached(key='test1')
+    def test1(self, argument, power):
+        '''running test1'''
+        return argument ** power
+
+    @c.cached(key='test2')
+    def test2(self):
+        '''running test2'''
+        return 1
+
+    @c.cached(key='test3')
+    def test3(self, argument, power):
+        '''running test3'''
+        return argument ** power
+
+
+def test_init_cache():
+    a = MyApp()
+
+    for _ in range(10):
+        a.test1(8, 0)
+        a.test2()
+
+    assert a.test2() == 1
+
+    print(c.dump())
+    assert len(c) == 2
+
+    # test3 should be initialized, but not cached
+    assert c._data_store['test3'] == INIT_CACHE_VALUE
+    assert len(c._data_store) == 3
+    assert 'test3' not in c
+
+
+def main():
+    test_init_cache()
+
+
+if __name__ == '__main__':
+    main()

--- a/yamicache/yamicache.py
+++ b/yamicache/yamicache.py
@@ -179,6 +179,7 @@ class Cache(collections.MutableMapping):
         with self._gc_lock:
             return self._data_store.popitem()
     ###########################################################################
+
     def _is_key_initialized(self, key):
         with self._gc_lock:
             return self._data_store.get(key) is INIT_CACHE_VALUE

--- a/yamicache/yamicache.py
+++ b/yamicache/yamicache.py
@@ -66,6 +66,7 @@ def nocache(cache_obj):
 
 
 CachedItem = collections.namedtuple('CachedItem', 'value timeout time_added')
+INIT_CACHE_VALUE = CachedItem("<value not cached yet>", None, None)
 
 
 class Cache(collections.MutableMapping):
@@ -125,10 +126,13 @@ class Cache(collections.MutableMapping):
 
     # Default stuff to override MutableMapping ABC ############################
     def __len__(self):
-        return len(self._data_store)
+        return len([x for x, y in self.items() if y is not INIT_CACHE_VALUE])
 
     def __getitem__(self, key):
+        '''Only return the item if it's not the INIT value'''
         with self._gc_lock:
+            if (key not in self._data_store) or (self._data_store[key] is INIT_CACHE_VALUE):
+                raise KeyError(key)
             return self._data_store[key]
 
     def __setitem__(self, key, value):
@@ -175,6 +179,9 @@ class Cache(collections.MutableMapping):
         with self._gc_lock:
             return self._data_store.popitem()
     ###########################################################################
+    def _is_key_initialized(self, key):
+        with self._gc_lock:
+            return self._data_store.get(key) is INIT_CACHE_VALUE
 
     def _from_timestamp(self, timestamp):
         '''Convert a timestamp string to an epoch value'''
@@ -205,6 +212,9 @@ class Cache(collections.MutableMapping):
         :param *args: Any ``*args`` used to call the function
         :param *kwargs: Any ``*kwargs`` used to call the function
         '''
+        if cached_key:
+            return cached_key
+
         key = cached_key
         if not key:
             key = dict(kwargs)
@@ -264,6 +274,15 @@ class Cache(collections.MutableMapping):
         '''
         if timeout and not isinstance(timeout, int):
             raise ValueError("timeout can only be `int`")
+        elif (key in self) or self._is_key_initialized(key):
+            # `key in self` will return False if the key either doesn't exist,
+            # or it's set to the INIT value.  Therefore, we need to call
+            # `_is_key_initialized()` to check that condition.
+            raise ValueError("cache key '%s' already exists" % key)
+        elif key:
+            # Set the default value so we can check for collisions when the
+            # next decorator is called.
+            self[key] = INIT_CACHE_VALUE
 
         def real_decorator(function, timeout=timeout):
             function.__cached_timeout__ = timeout or self._default_timeout
@@ -285,7 +304,7 @@ class Cache(collections.MutableMapping):
                     timeout = function.__cached_timeout__
 
                 try:
-                    if cache_key in self:
+                    if cache_key in self and (self[cache_key] is not INIT_CACHE_VALUE):
                         result = self[cache_key]
                         if (not result.timeout) or (result.timeout and (time.time() <= self._from_timestamp(result.timeout))):
                             self._debug_print('cache hit : %s' % cache_key)


### PR DESCRIPTION
User may not use the same key value twice.  This will raise a `ValueError` on instantiation.