### PR TITLE
Removing state pollution by clearing `Cache c`

### DIFF
--- a/tests/test_noclass.py
+++ b/tests/test_noclass.py
@@ -28,6 +28,7 @@ def test_main():
         my_func(2, 3)
 
     assert len(c) == 1
+    c.clear()
 
 
 def test_lists():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_main` by cleaning `Cache` object `c` by calling method `clear`

The test can fail in this way if `c` is not cleaned after executing test code:
```
Expected :0
Actual   :1
<Click to see difference>

def test_main():
        assert len(c) == 0
    
        for _ in [0, 1, 2, 3, 4, 5]:
            my_func(2, 3)
    
        assert len(c) == 1
>       assert len(c) == 0
E       assert 1 == 0
