### PR TITLE
Removing state pollution by clearing `Cache c`

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -77,6 +77,7 @@ def test_serialization(cache_obj):
     assert c._data_store == orig
 
     os.unlink(filepath)
+    c.clear()
 
 
 def main():


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_serialization` by removing state pollution by clearing `Cache c` by calling method `clear()`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_serialization.py::test_serialization`:

```
>       assert len(c) == 1
E       assert 4 == 1
E        +  where 4 = len(<yamicache.yamicache.Cache object at 0x7fa027f5b5b0>)
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
